### PR TITLE
[Fix] #11 - pdf에서 글자 추출 못하는 버그 대응

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.apache.poi:poi-ooxml:5.2.4'
     implementation 'org.apache.poi:poi-scratchpad:5.2.4'
     implementation 'org.apache.pdfbox:pdfbox:2.0.29'
+    implementation 'net.sourceforge.tess4j:tess4j:5.11.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 

--- a/src/main/java/org/unilab/improfessorbe/domain/problem/parser/PdfFileParser.java
+++ b/src/main/java/org/unilab/improfessorbe/domain/problem/parser/PdfFileParser.java
@@ -1,19 +1,44 @@
 package org.unilab.improfessorbe.domain.problem.parser;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.apache.pdfbox.rendering.PDFRenderer; // PDF를 이미지로 렌더링하기 위해 추가
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import org.unilab.improfessorbe.global.exception.CustomException;
+import org.unilab.improfessorbe.global.exception.ErrorCode;
 
-import lombok.RequiredArgsConstructor;
+import net.sourceforge.tess4j.Tesseract; // OCR 엔진
+import net.sourceforge.tess4j.TesseractException;
 
 @Component
-@RequiredArgsConstructor
-public class PdfFileParser implements FileParser {
+public class PdfFileParser implements FileParser { // 클래스 이름 변경 권장 (기존과 구분)
+
+	private static final int MIN_TEXT_LENGTH_THRESHOLD = 100;
+	// private static final int OCR_DPI = 150; // 300 → 150으로 낮춤
 
 	private final TextPreprocessor textPreprocessor;
+	// Tesseract 인스턴스를 필드로 설정 (싱글턴으로 관리)
+	private final Tesseract tesseract;
+
+	// 생성자에서 Tesseract 설정 (Dependency Injection으로 관리할 수도 있습니다)
+	public PdfFileParser(TextPreprocessor textPreprocessor, @Value("${tesseract.datapath}") String tesseractDataPath) {
+		this.textPreprocessor = textPreprocessor;
+		this.tesseract = new Tesseract();
+
+		// OCR 엔진 경로 및 언어 설정
+		this.tesseract.setDatapath(tesseractDataPath);
+		this.tesseract.setLanguage("kor+eng");
+		this.tesseract.setPageSegMode(1); // Automatic page segmentation with OSD
+		this.tesseract.setOcrEngineMode(1); // Neural nets LSTM engine only (빠름)
+	}
 
 	@Override
 	public boolean supports(String extension) {
@@ -23,9 +48,54 @@ public class PdfFileParser implements FileParser {
 	@Override
 	public String parse(MultipartFile file) throws IOException {
 		try (PDDocument document = PDDocument.load(file.getInputStream())) {
+
+			// 1. **PDFBox (텍스트 레이어) 추출을 먼저 시도 (빠른 경로)**
 			PDFTextStripper stripper = new PDFTextStripper();
-			String rawText = stripper.getText(document);
-			return textPreprocessor.preprocess(rawText);
+			String rawText = stripper.getText(document).trim();
+
+			// 텍스트가 충분히 추출되었다면 OCR 불필요
+			if (rawText.length() > MIN_TEXT_LENGTH_THRESHOLD) {
+				return textPreprocessor.preprocess(rawText);
+			}else{
+				throw new CustomException(ErrorCode.NO_EXTRACTABLE_TEXT);
+			}
+
+			/*// 2. **텍스트 추출 실패 시 OCR 시도 (이미지 기반 문서 처리)**
+			System.out.println("Insufficient text extracted via PDFBox. Attempting OCR...");
+			String ocrText = performOcr(document);
+			return textPreprocessor.preprocess(ocrText);*/
+
+		} catch (Exception e) {
+			throw new IOException("PDF/OCR processing failed: " + e.getMessage(), e);
 		}
 	}
+
+	/*// PDF 페이지를 이미지로 렌더링하고 OCR을 수행하는 내부 메서드
+	private String performOcr(PDDocument document) throws IOException, TesseractException {
+		PDFRenderer pdfRenderer = new PDFRenderer(document);
+		StringBuilder ocrText = new StringBuilder();
+		File tempFile = null;
+
+		for (int i = 0; i < document.getNumberOfPages(); i++) {
+			// DPI 설정이 OCR 정확도에 중요합니다 (300 DPI 권장)
+			BufferedImage bim = pdfRenderer.renderImageWithDPI(i, OCR_DPI);
+
+			try {
+				// 임시 파일 생성 및 이미지 저장
+				tempFile = File.createTempFile("pdf-page-" + i + "-", ".png");
+				ImageIO.write(bim, "png", tempFile);
+
+				// Tess4J를 사용하여 이미지에서 텍스트 추출 (OCR)
+				String pageText = tesseract.doOCR(tempFile);
+				ocrText.append(pageText).append("\n\n");
+
+			} finally {
+				// 임시 파일 정리
+				if (tempFile != null) {
+					Files.deleteIfExists(tempFile.toPath());
+				}
+			}
+		}
+		return ocrText.toString();
+	}*/
 }

--- a/src/main/java/org/unilab/improfessorbe/domain/problem/service/ProblemService.java
+++ b/src/main/java/org/unilab/improfessorbe/domain/problem/service/ProblemService.java
@@ -174,27 +174,27 @@ public class ProblemService {
 				formatContent = fileParseService.parseFileList(formatFiles, "형식");
 			}
 
-			callback.onProgress("file_parsing", 10, "파일 읽기 완료!");
+			callback.onProgress("file_parsing", 29, "파일 읽기 완료!");
 			log.info("개념 파일 글자수: {}개 / 형식 파일 글자수: {}개",
 				conceptContent.length(), formatContent.length());
 
-			// 2. 개념 추출 (12% → 43%)
-			callback.onProgress("concept_extraction", 12, "중요 개념을 추출하는 중...");
+			// 2. 개념 추출 (29% → 65%)
+			callback.onProgress("concept_extraction", 33, "중요 개념을 추출하는 중...");
 
 			ConceptExtractionResult result = conceptExtractorService.extractConcepts(conceptContent);
 			String conceptExtraction = result.toFormattedString();
 
-			callback.onProgress("concept_extraction", 43, "개념 추출 완료!");
+			callback.onProgress("concept_extraction", 65, "개념 추출 완료!");
 
-			// 3. 문제 생성 (43% → 89%)
-			callback.onProgress("problem_generation", 45, "AI가 문제를 생성하는 중...");
+			// 3. 문제 생성 (69% → 93%)
+			callback.onProgress("problem_generation", 69, "AI가 문제를 생성하는 중...");
 
 			String problemText = geminiApiClient.generateProblems(conceptExtraction, formatContent);
 			List<ProblemResponse> responses = problemTextParser.parseProblemText(problemText);
 
-			callback.onProgress("problem_generation", 89, "문제 생성 완료!");
+			callback.onProgress("problem_generation", 93, "문제 생성 완료!");
 
-			// 4. 저장 (89% → 100%)
+			// 4. 저장 (95% → 100%)
 			callback.onProgress("saving", 95, "생성된 문제를 저장하는 중...");
 
 			String roundName = conceptFiles.get(0).getOriginalFilename() + '_' + LocalDateTime.now()

--- a/src/main/java/org/unilab/improfessorbe/domain/user/service/UserService.java
+++ b/src/main/java/org/unilab/improfessorbe/domain/user/service/UserService.java
@@ -112,7 +112,7 @@ public class UserService {
 			log.error("login error: not valid password");
 			throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
 		} catch (Exception e) {
-			log.error("login error");
+			log.error("login error - external service failed: ", e);
 			throw new CustomException(ErrorCode.EXTERNAL_SERVICE_ERROR);
 		}
 	}

--- a/src/main/java/org/unilab/improfessorbe/global/exception/ErrorCode.java
+++ b/src/main/java/org/unilab/improfessorbe/global/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 	FILE_TOO_LARGE("P003", "파일 크기가 너무 큽니다.", HttpStatus.BAD_REQUEST),
 	UNSUPPORTED_FILE_TYPE("P004", "지원하지 않는 파일 형식입니다.", HttpStatus.BAD_REQUEST),
 	EMPTY_FILE("P005", "업로드된 파일이 비어있습니다.", HttpStatus.BAD_REQUEST),
+	NO_EXTRACTABLE_TEXT("P006", "업로드하신 강의자료에서 텍스트를 추출할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
 	// Problem(생성된 문제 후처리 중 오류코드)
 	PROBLEM_TEXT_EMPTY("P006", "생성된 문제의 텍스트가 비어있습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호가 있다면 적어주세요 -->
#11

## 개요
<!-- 어떤 이슈를 해결하거나 어떤 기능을 추가했는지 간략히 작성 -->
pdf에서 글자 추출 못하는 버그를 해결하려 했으나 서버 스펙에 막힘

## 작업 내용
<!-- 실제로 작업한 내용 리스트 -->
- ec2에 ocr 라이브러리 Tessract 설치
- 코드에 ocr 라이브러리 활용하여 이미지화 한 후 텍스트 추출하는 기능 반영
- ec2 스팩업(t3.micro > m3.small)로 진행해도 응답시간 3분 이상 걸려서 사용 불가능
  - 그 이상 스팩업하면 프리티어 한달 도 사용하지 못함
  - 그래서 업로드한 pdf의 텍스트 추출하지 못하면 그냥 예외 던짐.  


##  기타
<!-- 리뷰어가 참고하면 좋을 사항 -->
